### PR TITLE
Return value for client.stream.* calls

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -15,25 +15,25 @@ var _qsAllowedProps = [
 streams.prototype.activity = function(args,done) {
 
     var endpoint = 'activities';
-    this._typeHelper(endpoint,args,done);
+    return this._typeHelper(endpoint,args,done);
 };
 
 streams.prototype.effort = function(args,done) {
 
     var endpoint = 'segment_efforts';
-    this._typeHelper(endpoint,args,done);
+    return this._typeHelper(endpoint,args,done);
 };
 
 streams.prototype.segment = function(args,done) {
 
     var endpoint = 'segments';
-    this._typeHelper(endpoint,args,done);
+    return this._typeHelper(endpoint,args,done);
 };
 
 streams.prototype.route = function(args,done) {
 
     var endpoint = 'routes';
-    this._typeHelper(endpoint,args,done);
+    return this._typeHelper(endpoint,args,done);
 };
 //===== streams endpoint =====
 


### PR DESCRIPTION
These endpoints didn’t return anything, making them unusable with the
promises version of the API.